### PR TITLE
Fix issue with spaceCase not matching all cases

### DIFF
--- a/src/space-case.js
+++ b/src/space-case.js
@@ -3,7 +3,7 @@ import R from 'ramda';
 // a -> a
 const spaceCase = R.compose(
   R.trim,
-  R.replace(/([a-z])([A-Z])/, '$1 $2'),
+  R.replace(/([a-z])([A-Z])/g, '$1 $2'),
   R.replace(/(\.|-|_)/g, ' ')
 );
 

--- a/test/space-case.js
+++ b/test/space-case.js
@@ -3,11 +3,11 @@ import spaceCase from '../src/space-case.js';
 
 describe('#spaceCase', () => {
   it('should spaceCase a string', () => {
-    assert.equal(spaceCase('camelCased'), 'camel Cased');
-    assert.equal(spaceCase('spinal-cased'), 'spinal cased');
-    assert.equal(spaceCase('snake_cased'), 'snake cased');
-    assert.equal(spaceCase('dot.notation'), 'dot notation');
-    assert.equal(spaceCase('space cased'), 'space cased');
+    assert.equal(spaceCase('camelCasedString'), 'camel Cased String');
+    assert.equal(spaceCase('spinal-cased-string'), 'spinal cased string');
+    assert.equal(spaceCase('snake_cased_string'), 'snake cased string');
+    assert.equal(spaceCase('dot.notation.string'), 'dot notation string');
+    assert.equal(spaceCase('space cased string'), 'space cased string');
     assert.equal(spaceCase('camelSpinal-snake_dot.cased'), 'camel Spinal snake dot cased');
   });
 });


### PR DESCRIPTION
spaceCase was only inserting a space after the first uppercase character match.
This was caused by not including a \g flag in the regular expression.

This PR closes #18 